### PR TITLE
Don't map IEnumUnknown

### DIFF
--- a/Mapping.xml
+++ b/Mapping.xml
@@ -144,7 +144,6 @@
     <bind from="IPropertyStore" to="SharpGen.Runtime.ComObject"/>
     <bind from="IPropertyBag2" to="SharpGen.Runtime.Win32.PropertyBag"/>
     <bind from="IClassFactory" to="SharpGen.Runtime.ComObject"/>
-    <bind from="IEnumUnknown" to="SharpGen.Runtime.ComObject"/>
     <bind from="IEnumString" to="SharpGen.Runtime.ComObject"/>
     <bind from="INamedPropertyStore" to="SharpGen.Runtime.ComObject"/>
 


### PR DESCRIPTION
Don't map IEnumUnknown to default ComObject because it may be used (e.g. in ICorDebug)