### PR TITLE
Equality members and operators for COM objects

### DIFF
--- a/ComObject.cs
+++ b/ComObject.cs
@@ -68,17 +68,7 @@ namespace SharpGen.Runtime
         /// <returns><c>true</c> if the native pointer is the same, <c>false</c> otherwise</returns>
         public static bool EqualsComObject<T>(T left, T right) where T : ComObject
         {
-            if (Equals(left, right))
-            {
-                return true;
-            }
-
-            if (left == null || right == null)
-            {
-                return false;
-            }
-
-            return (left.NativePointer == right.NativePointer);
+            return (Equals(left, right));
         }
 
         ///<summary>
@@ -231,6 +221,35 @@ namespace SharpGen.Runtime
             }
 
             base.Dispose(disposing);
+        }
+
+        protected bool Equals(ComObject other)
+        {
+            return EqualsComObject(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj is ComObject comObject)
+                return (NativePointer == comObject.NativePointer);
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return NativePointer.GetHashCode();
+        }
+
+        public static bool operator ==(ComObject left, ComObject right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(ComObject left, ComObject right)
+        {
+            return !Equals(left, right);
         }
     }
 }


### PR DESCRIPTION
Add equality members and operator overloads to support classic COM objects comparison behavior (when you compares references in classic COM it checks theirs underlying objects).

We have a lot of code in our debugger where we compare COM objects just as references. After migration to SharpGen I've faced with a lot of issues because reference equality fails because SharpGen creates new objects instead of using the single proxy per each real native object. Since it's very hard to find all such code I just added equality operator and everythig started to work well. I guess other developer can face with the same problem while migrating their projects from classic COM