### PR TITLE
Remove erroneous binding to nonexistent class

### DIFF
--- a/Mapping.xml
+++ b/Mapping.xml
@@ -123,7 +123,6 @@
     <bind from="HRESULT" to="SharpGen.Runtime.Result" />
     <bind from="SIZE_T" to="SharpGen.Runtime.PointerSize" />
     <bind from="SSIZE_T" to="SharpGen.Runtime.PointerSize" />
-    <bind from="MSG" to="SharpGen.Runtime.Win32.NativeMessage" />
     <bind from="ULARGE_INTEGER" to="System.UInt64" />
     <bind from="LARGE_INTEGER" to="System.Int64" />
     <bind from="FILETIME" to="System.Int64" />


### PR DESCRIPTION
`SharpGen.Runtime.Win32.NativeMessage` doesn't exist (never did). It was [here](https://github.com/sharpdx/SharpDX/blob/master/Source/SharpDX/Win32/NativeMessage.cs) at SharpDX. Since this library is about COM, it doesn't need to take care of window message queues.

Discovered when porting Vortice to use _SharpGen.Runtime.COM_ instead of _Vortice.Runtime.COM_.

Cc @amerkoleci 